### PR TITLE
Remove unused SYS variable

### DIFF
--- a/zfs_stats_
+++ b/zfs_stats_
@@ -17,11 +17,6 @@
 
 FUNCTION=$(basename $0 | cut -d_ -f3)
 BC='/usr/bin/bc -q'
-SYS='/sbin/sysctl -n'
-
-#
-# Sysctl macros
-#
 
 
 CONTENT=`cat /proc/spl/kstat/zfs/arcstats`


### PR DESCRIPTION
Sysctl is not actually used in the script so remove the associated
variable to avoid confusion about the dependencies of the script.
Note that sysctl is not consistely installed as /sbin/sysctl, e.g. on
Gentoo Linux it is installed as /usr/sbin/sysctl.